### PR TITLE
Feat(issue 44) : 지원서 페이지 관련 공통 레이아웃 및 react-hook-form

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "react-dnd": "^16.0.1",
         "react-dnd-html5-backend": "^16.0.1",
         "react-dom": "^18.2.0",
-        "react-hook-form": "^7.46.1",
+        "react-hook-form": "^7.49.3",
         "react-modal": "^3.16.1",
         "react-redux": "^8.1.2",
         "react-router-dom": "^6.14.1",
@@ -17604,11 +17604,12 @@
       "dev": true
     },
     "node_modules/react-hook-form": {
-      "version": "7.47.0",
-      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.47.0.tgz",
-      "integrity": "sha512-F/TroLjTICipmHeFlMrLtNLceO2xr1jU3CyiNla5zdwsGUGu2UOxxR4UyJgLlhMwLW/Wzp4cpJ7CPfgJIeKdSg==",
+      "version": "7.49.3",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.49.3.tgz",
+      "integrity": "sha512-foD6r3juidAT1cOZzpmD/gOKt7fRsDhXXZ0y28+Al1CHgX+AY1qIN9VSIIItXRq1dN68QrRwl1ORFlwjBaAqeQ==",
       "engines": {
-        "node": ">=12.22.0"
+        "node": ">=18",
+        "pnpm": "8"
       },
       "funding": {
         "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "react-dnd": "^16.0.1",
     "react-dnd-html5-backend": "^16.0.1",
     "react-dom": "^18.2.0",
-    "react-hook-form": "^7.46.1",
+    "react-hook-form": "^7.49.3",
     "react-modal": "^3.16.1",
     "react-redux": "^8.1.2",
     "react-router-dom": "^6.14.1",

--- a/src/DefaultLayout.tsx
+++ b/src/DefaultLayout.tsx
@@ -4,7 +4,7 @@ import AppContent from './components/default/Content';
 
 function DefaultLayout() {
   const userInfo = JSON.parse(localStorage.getItem('userInfo') || '{}');
-  console.log(!!userInfo);
+
   return (
     <Root>
       {userInfo && <Header />}

--- a/src/components/application/ApplicationLayout.tsx
+++ b/src/components/application/ApplicationLayout.tsx
@@ -1,0 +1,112 @@
+import { ContentContainer, Wrapper } from './ApplicationLayoutStyledComponents';
+import ApplicationRow from './ApplicationRow';
+import ApplicationRowEdit from './ApplicationRowEdit';
+import { useNavigate } from 'react-router-dom';
+
+interface ApplicationLayoutProps {
+  type: 'edit' | 'default';
+}
+
+interface Data {
+  [key: string]: string;
+}
+
+const DummyData: Data = {
+  companyName: '현대글로비스',
+  team: '',
+  position: '디자인',
+  specificPosition: '',
+  processes: '',
+  jobDescription: '오토벨 광고 컨텐츠 크리에이티브 컨셉 도출 및 기획 (DA/SNS/영상 콘텐츠 등)',
+  requiredCapability: 'Figma 활용 숙련자',
+  url: 'https://glovis.recruiter.co.kr/app/jobnotice/list',
+  location: '서울 성동구',
+  preferredQualification: 'IT 및 자동차 산업에 대한 이해도 보유',
+  contact: 'sj.lee@glovis.net 02-6393-9552',
+  workType: '재택가능',
+  employmentType: '정규직',
+  careerRequirement: '무관',
+};
+
+const InputContentArr = [
+  { label: '회사명', name: 'companyName' },
+  { label: '부서', name: 'team' },
+  { label: '직군', name: 'position' },
+  { label: '세부직무', name: 'specificPosition' },
+  { label: '전형 단계', name: 'processes' },
+  { label: '주요 업무', name: 'jobDescription' },
+  { label: '필수 역량', name: 'requiredCapability' },
+  { label: '경력 조건', name: 'requiredCapability' },
+  { label: '공고 URL', name: 'url' },
+  { label: '회사 위치', name: 'location' },
+  { label: '우대 사항', name: 'preferredQualification' },
+  { label: '채용 담당', name: 'contact' },
+];
+
+const RadioContentArr = [
+  { label: '고용 형태', name: 'employmentType' },
+  { label: '경력 조건', name: 'careerRequirement' },
+  { label: '근무 형태', name: 'workType' },
+];
+
+const ApplicationLayout = ({ type }: ApplicationLayoutProps) => {
+  const navigate = useNavigate();
+
+  const handleSubmit = (e: any, type: 'default' | 'edit') => {
+    e.preventDefault();
+
+    if (type === 'edit') {
+      navigate('/applicatioEdit');
+      return;
+    }
+
+    //   TODO 수정 API 연결
+    // TODO 우선 상세페이지로 이동, 이후 수정 필요
+    navigate('/applicationDetail');
+  };
+
+  return (
+    <Wrapper>
+      <div className='title'>내 지원서</div>
+      <ContentContainer>
+        {InputContentArr.map((e, index) =>
+          type === 'edit' ? (
+            <ApplicationRowEdit
+              key={index}
+              label={e.label}
+              name={e.name}
+              value={DummyData[e.name]}
+            />
+          ) : (
+            <ApplicationRow key={index} label={e.label} name={e.name} value={DummyData[e.name]} />
+          ),
+        )}
+
+        {/* TODO Radio Component 교체 필요 */}
+        {RadioContentArr.map((e, index) => {
+          return (
+            <ApplicationRow key={index} label={e.label} name={e.name} value={DummyData[e.name]} />
+          );
+        })}
+
+        {/* TODO button component 교체 필요 */}
+        {type === 'default' ? (
+          <div className='btnContainer'>
+            <button>삭제하기</button>
+            <button onClick={e => handleSubmit(e, 'edit')} type='submit'>
+              수정하기
+            </button>
+          </div>
+        ) : (
+          <div className={`btnContainer`}>
+            <button onClick={e => handleSubmit(e, 'default')} type='button'>
+              작성완료
+            </button>
+          </div>
+        )}
+      </ContentContainer>
+    </Wrapper>
+  );
+};
+
+export default ApplicationLayout;

--- a/src/components/application/ApplicationLayout.tsx
+++ b/src/components/application/ApplicationLayout.tsx
@@ -1,46 +1,28 @@
+import { FieldValues, useForm } from 'react-hook-form';
 import { ContentContainer, Wrapper } from './ApplicationLayoutStyledComponents';
 import ApplicationRow from './ApplicationRow';
 import ApplicationRowEdit from './ApplicationRowEdit';
 import { useNavigate } from 'react-router-dom';
 
 interface ApplicationLayoutProps {
-  type: 'edit' | 'default';
+  type: 'edit' | 'default' | 'add';
+  data?: any; //TODO api 연결 이후 응답 데이터 type으로 수정 필요
 }
 
-interface Data {
-  [key: string]: string;
-}
-
-const DummyData: Data = {
-  companyName: '현대글로비스',
-  team: '',
-  position: '디자인',
-  specificPosition: '',
-  processes: '',
-  jobDescription: '오토벨 광고 컨텐츠 크리에이티브 컨셉 도출 및 기획 (DA/SNS/영상 콘텐츠 등)',
-  requiredCapability: 'Figma 활용 숙련자',
-  url: 'https://glovis.recruiter.co.kr/app/jobnotice/list',
-  location: '서울 성동구',
-  preferredQualification: 'IT 및 자동차 산업에 대한 이해도 보유',
-  contact: 'sj.lee@glovis.net 02-6393-9552',
-  workType: '재택가능',
-  employmentType: '정규직',
-  careerRequirement: '무관',
-};
-
+// TODO 필수인지 여부 이후 api 연동 시 수정 필요
 const InputContentArr = [
-  { label: '회사명', name: 'companyName' },
-  { label: '부서', name: 'team' },
-  { label: '직군', name: 'position' },
-  { label: '세부직무', name: 'specificPosition' },
-  { label: '전형 단계', name: 'processes' },
-  { label: '주요 업무', name: 'jobDescription' },
-  { label: '필수 역량', name: 'requiredCapability' },
-  { label: '경력 조건', name: 'requiredCapability' },
-  { label: '공고 URL', name: 'url' },
-  { label: '회사 위치', name: 'location' },
-  { label: '우대 사항', name: 'preferredQualification' },
-  { label: '채용 담당', name: 'contact' },
+  { label: '회사명', name: 'companyName', isRequired: true },
+  { label: '부서', name: 'team', isRequired: false },
+  { label: '직군', name: 'position', isRequired: true },
+  { label: '세부직무', name: 'specificPosition', isRequired: false },
+  { label: '전형 단계', name: 'processes', isRequired: false },
+  { label: '주요 업무', name: 'jobDescription', isRequired: true },
+  { label: '필수 역량', name: 'requiredCapability', isRequired: false },
+  { label: '경력 조건', name: 'requiredCapability', isRequired: false },
+  { label: '공고 URL', name: 'url', isRequired: true },
+  { label: '회사 위치', name: 'location', isRequired: false },
+  { label: '우대 사항', name: 'preferredQualification', isRequired: false },
+  { label: '채용 담당', name: 'contact', isRequired: false },
 ];
 
 const RadioContentArr = [
@@ -49,59 +31,76 @@ const RadioContentArr = [
   { label: '근무 형태', name: 'workType' },
 ];
 
-const ApplicationLayout = ({ type }: ApplicationLayoutProps) => {
+const ApplicationLayout = ({ type, data = [] }: ApplicationLayoutProps) => {
   const navigate = useNavigate();
 
-  const handleSubmit = (e: any, type: 'default' | 'edit') => {
-    e.preventDefault();
+  const methods = useForm<FieldValues>({
+    mode: 'onChange',
+    defaultValues: {
+      companyName: data.companyName || '',
+      team: data.team || '',
+      position: data.position || '',
+      specificPosition: data.specificPosition || '',
+      processes: data.processes || '',
+      jobDescription: data.jobDescription || '',
+      requiredCapability: data.requiredCapability || '',
+      url: data.url || '',
+      location: data.location || '',
+      preferredQualification: data.preferredQualification || '',
+      contact: data.contact || '',
+      workType: data.workType || '',
+      employmentType: data.employmentType || '',
+      careerRequirement: data.careerRequirement || '',
+    },
+  });
 
+  const { handleSubmit, control } = methods;
+
+  // 작성완료 버튼 클릭 시 동작, data를 통해서 입력값 확인 가능
+  const onSubmit = (data: FieldValues) => {
+    console.log(data);
     if (type === 'edit') {
-      navigate('/application/edit');
+      //   TODO 수정 API 연결
       return;
     }
 
-    //   TODO 수정 API 연결
-    // TODO 우선 상세페이지로 이동, 이후 수정 필요
-    navigate('/applicationDetail');
+    // TODO 등록 API 연결
   };
 
   return (
     <Wrapper>
       <div className='title'>내 지원서</div>
-      <ContentContainer>
+      <ContentContainer onSubmit={handleSubmit(onSubmit)}>
         {InputContentArr.map((e, index) =>
-          type === 'edit' ? (
+          type !== 'default' ? (
             <ApplicationRowEdit
               key={index}
               label={e.label}
               name={e.name}
-              value={DummyData[e.name]}
+              control={control}
+              isRequired={e.isRequired}
             />
           ) : (
-            <ApplicationRow key={index} label={e.label} name={e.name} value={DummyData[e.name]} />
+            <ApplicationRow key={index} label={e.label} name={e.name} value={data[e.name]} />
           ),
         )}
 
         {/* TODO Radio Component 교체 필요 */}
         {RadioContentArr.map((e, index) => {
-          return (
-            <ApplicationRow key={index} label={e.label} name={e.name} value={DummyData[e.name]} />
-          );
+          return <ApplicationRow key={index} label={e.label} name={e.name} value={data[e.name]} />;
         })}
 
         {/* TODO button component 교체 필요 */}
         {type === 'default' ? (
           <div className='btnContainer'>
-            <button>삭제하기</button>
-            <button onClick={e => handleSubmit(e, 'edit')} type='submit'>
+            <button type='button'>삭제하기</button>
+            <button type='button' onClick={() => navigate('/application/edit')}>
               수정하기
             </button>
           </div>
         ) : (
           <div className={`btnContainer`}>
-            <button onClick={e => handleSubmit(e, 'default')} type='button'>
-              작성완료
-            </button>
+            <button type='submit'>작성완료</button>
           </div>
         )}
       </ContentContainer>

--- a/src/components/application/ApplicationLayout.tsx
+++ b/src/components/application/ApplicationLayout.tsx
@@ -56,7 +56,7 @@ const ApplicationLayout = ({ type }: ApplicationLayoutProps) => {
     e.preventDefault();
 
     if (type === 'edit') {
-      navigate('/applicatioEdit');
+      navigate('/application/edit');
       return;
     }
 

--- a/src/components/application/ApplicationLayout.tsx
+++ b/src/components/application/ApplicationLayout.tsx
@@ -87,7 +87,15 @@ const ApplicationLayout = ({ type, data = [] }: ApplicationLayoutProps) => {
 
         {/* TODO Radio Component 교체 필요 */}
         {RadioContentArr.map((e, index) => {
-          return <ApplicationRow key={index} label={e.label} name={e.name} value={data[e.name]} />;
+          return (
+            <ApplicationRowEdit
+              key={index}
+              label={e.label}
+              name={e.name}
+              control={control}
+              isRequired={false}
+            />
+          );
         })}
 
         {/* TODO button component 교체 필요 */}

--- a/src/components/application/ApplicationLayoutStyledComponents.ts
+++ b/src/components/application/ApplicationLayoutStyledComponents.ts
@@ -1,0 +1,28 @@
+import styled from 'styled-components';
+
+export const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 5.4rem 11rem;
+
+  .title {
+    color: #333;
+    text-align: center;
+    font-size: 3rem;
+    font-weight: 700;
+  }
+`;
+
+export const ContentContainer = styled.form`
+  display: flex;
+  flex-direction: column;
+  margin: 3.3rem 0 5rem;
+  gap: 2.7rem;
+
+  .btnContainer {
+    align-self: center;
+    display: flex;
+    flex-direction: row;
+  }
+`;

--- a/src/components/application/ApplicationRow.tsx
+++ b/src/components/application/ApplicationRow.tsx
@@ -1,0 +1,49 @@
+import styled from 'styled-components';
+
+interface ApplicationRowProps {
+  label: string;
+  name: string;
+  value?: string;
+}
+
+const ApplicationRow = ({ label, name, value }: ApplicationRowProps) => {
+  return (
+    <RowContainer>
+      <label>{label}</label>
+      {name === 'url' ? (
+        <a className='content url' href={value}>
+          채용사이트
+        </a>
+      ) : (
+        <div className='content'>{value === '' ? '-' : value}</div>
+      )}
+    </RowContainer>
+  );
+};
+
+export default ApplicationRow;
+
+const RowContainer = styled.div`
+  display: flex;
+  gap: 0.5rem;
+
+  label {
+    width: 11rem;
+    color: #969696;
+    font-size: 1.8rem;
+    font-weight: 500;
+  }
+
+  .content {
+    width: 32.9rem;
+    color: #464646;
+    font-size: 1.6rem;
+    font-weight: 500;
+  }
+
+  .url {
+    color: #3253ff;
+    font-weight: 600;
+    text-decoration-line: underline;
+  }
+`;

--- a/src/components/application/ApplicationRowEdit.tsx
+++ b/src/components/application/ApplicationRowEdit.tsx
@@ -1,0 +1,49 @@
+import styled from 'styled-components';
+
+interface ApplicationRowProps {
+  label: string;
+  name: string;
+  value?: string;
+}
+
+const ApplicationRowEdit = ({ label, name, value }: ApplicationRowProps) => {
+  return (
+    <RowContainer>
+      <label>{label}</label>
+      {/* TODO input component 교체 필요 */}
+      <input className='content' name={name} value={value} placeholder='선택 입력' />
+    </RowContainer>
+  );
+};
+
+export default ApplicationRowEdit;
+
+const RowContainer = styled.div`
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+
+  label {
+    width: 11rem;
+    color: #969696;
+    font-size: 1.8rem;
+    font-weight: 500;
+  }
+
+  .content {
+    padding: 0.5rem 2.6rem;
+    width: 32.9rem;
+    color: #464646;
+    font-size: 1.6rem;
+    font-weight: 600;
+    border-radius: 1rem;
+    border: 0.5px solid #969696;
+    height: 4rem;
+
+    &::placeholder {
+      color: #d9d9d9;
+      font-size: 1.5rem;
+      font-weight: 500;
+    }
+  }
+`;

--- a/src/components/application/ApplicationRowEdit.tsx
+++ b/src/components/application/ApplicationRowEdit.tsx
@@ -1,17 +1,41 @@
+import { Control, FieldPath, FieldValues, useController } from 'react-hook-form';
 import styled from 'styled-components';
 
 interface ApplicationRowProps {
   label: string;
-  name: string;
-  value?: string;
+  control: Control<FieldValues>;
+  name: FieldPath<FieldValues>;
+  isRequired: boolean;
 }
 
-const ApplicationRowEdit = ({ label, name, value }: ApplicationRowProps) => {
+const ApplicationRowEdit = ({ label, name, control, isRequired }: ApplicationRowProps) => {
+  const {
+    field,
+    // fieldState: { error },
+  } = useController({
+    name,
+    control,
+    rules: isRequired
+      ? {
+          required: { value: true, message: '값을 입력해주세요' },
+        }
+      : {},
+  });
+
   return (
     <RowContainer>
       <label>{label}</label>
       {/* TODO input component 교체 필요 */}
-      <input className='content' name={name} value={value} placeholder='선택 입력' />
+      <input
+        className='content'
+        placeholder='선택 입력'
+        name={field.name}
+        value={field.value}
+        id={field.name}
+        onChange={field.onChange}
+      />
+      {/* TODO error 처리 필요할 경우 사용 */}
+      {/* {error && <div>{error.message}</div>} */}
     </RowContainer>
   );
 };

--- a/src/components/default/header/Header.tsx
+++ b/src/components/default/header/Header.tsx
@@ -14,6 +14,14 @@ const Header = () => {
   const [isSelect, setIsSelect] = useState('공고리스트');
   const navigate = useNavigate();
 
+  const handlePage = (item: string) => {
+    if (item === '지원서 추가') {
+      setIsSelect(item);
+      navigate('/application/add');
+    }
+    //TODO 다른 페이지 개발 시 이동 처리 추가 필요
+  };
+
   return (
     <HeaderContainer>
       <div className='headerContainer'>
@@ -25,7 +33,7 @@ const Header = () => {
                 <div
                   className={`menuItem ${isSelect === e ? 'active' : ''}`}
                   key={index}
-                  onClick={() => setIsSelect(e)}>
+                  onClick={() => handlePage(e)}>
                   {e}
                 </div>
               );

--- a/src/pages/applications/ApplicationAdd.tsx
+++ b/src/pages/applications/ApplicationAdd.tsx
@@ -1,0 +1,7 @@
+import ApplicationLayout from 'components/application/ApplicationLayout';
+
+const ApplicationAdd = () => {
+  return <ApplicationLayout type='edit' />;
+};
+
+export default ApplicationAdd;

--- a/src/pages/applications/ApplicationDetail.tsx
+++ b/src/pages/applications/ApplicationDetail.tsx
@@ -1,0 +1,7 @@
+import ApplicationLayout from 'components/application/ApplicationLayout';
+
+const ApplicationDetail = () => {
+  return <ApplicationLayout type='default' />;
+};
+
+export default ApplicationDetail;

--- a/src/pages/applications/ApplicationDetail.tsx
+++ b/src/pages/applications/ApplicationDetail.tsx
@@ -1,6 +1,7 @@
 import ApplicationLayout from 'components/application/ApplicationLayout';
 
 const ApplicationDetail = () => {
+  // TODO 이후 id 혹은 조회한 데이터 자체를 넘겨줄 필요 있음
   return <ApplicationLayout type='default' />;
 };
 

--- a/src/pages/applications/ApplicationDetail.tsx
+++ b/src/pages/applications/ApplicationDetail.tsx
@@ -1,8 +1,29 @@
 import ApplicationLayout from 'components/application/ApplicationLayout';
 
+interface Data {
+  [key: string]: string;
+}
+
+const DummyData: Data = {
+  companyName: '현대글로비스',
+  team: '',
+  position: '디자인',
+  specificPosition: '',
+  processes: '',
+  jobDescription: '오토벨 광고 컨텐츠 크리에이티브 컨셉 도출 및 기획 (DA/SNS/영상 콘텐츠 등)',
+  requiredCapability: 'Figma 활용 숙련자',
+  url: 'https://glovis.recruiter.co.kr/app/jobnotice/list',
+  location: '서울 성동구',
+  preferredQualification: 'IT 및 자동차 산업에 대한 이해도 보유',
+  contact: 'sj.lee@glovis.net 02-6393-9552',
+  workType: '재택가능',
+  employmentType: '정규직',
+  careerRequirement: '무관',
+};
+
 const ApplicationDetail = () => {
-  // TODO 이후 id 혹은 조회한 데이터 자체를 넘겨줄 필요 있음
-  return <ApplicationLayout type='default' />;
+  // TODO api 연동 후 data 교체 필요
+  return <ApplicationLayout type='default' data={DummyData} />;
 };
 
 export default ApplicationDetail;

--- a/src/pages/applications/ApplicationEdit.tsx
+++ b/src/pages/applications/ApplicationEdit.tsx
@@ -1,0 +1,7 @@
+import ApplicationLayout from 'components/application/ApplicationLayout';
+
+const ApplicationEdit = () => {
+  return <ApplicationLayout type='edit' />;
+};
+
+export default ApplicationEdit;

--- a/src/pages/applications/ApplicationEdit.tsx
+++ b/src/pages/applications/ApplicationEdit.tsx
@@ -1,6 +1,7 @@
 import ApplicationLayout from 'components/application/ApplicationLayout';
 
 const ApplicationEdit = () => {
+  // TODO 이후 id 혹은 조회한 데이터 자체를 넘겨줄 필요 있음
   return <ApplicationLayout type='edit' />;
 };
 

--- a/src/pages/applications/ApplicationEdit.tsx
+++ b/src/pages/applications/ApplicationEdit.tsx
@@ -1,8 +1,28 @@
 import ApplicationLayout from 'components/application/ApplicationLayout';
+interface Data {
+  [key: string]: string;
+}
+
+const DummyData: Data = {
+  companyName: '현대글로비스',
+  team: '',
+  position: '디자인',
+  specificPosition: '',
+  processes: '',
+  jobDescription: '오토벨 광고 컨텐츠 크리에이티브 컨셉 도출 및 기획 (DA/SNS/영상 콘텐츠 등)',
+  requiredCapability: 'Figma 활용 숙련자',
+  url: 'https://glovis.recruiter.co.kr/app/jobnotice/list',
+  location: '서울 성동구',
+  preferredQualification: 'IT 및 자동차 산업에 대한 이해도 보유',
+  contact: 'sj.lee@glovis.net 02-6393-9552',
+  workType: '재택가능',
+  employmentType: '정규직',
+  careerRequirement: '무관',
+};
 
 const ApplicationEdit = () => {
-  // TODO 이후 id 혹은 조회한 데이터 자체를 넘겨줄 필요 있음
-  return <ApplicationLayout type='edit' />;
+  // TODO api 연동 후 data 교체 필요
+  return <ApplicationLayout type='edit' data={DummyData} />;
 };
 
 export default ApplicationEdit;

--- a/src/pages/applications/index.tsx
+++ b/src/pages/applications/index.tsx
@@ -1,0 +1,26 @@
+import React, { Suspense } from 'react';
+import { Route, Routes } from 'react-router-dom';
+
+const ApplicationDetail = React.lazy(() => import('./ApplicationDetail'));
+const ApplicationEdit = React.lazy(() => import('./ApplicationEdit'));
+
+const routes = [
+  { path: '/detail', element: <ApplicationDetail /> },
+  { path: '/edit', element: <ApplicationEdit /> },
+];
+
+const loading = <div>화면을 불러오는 중 입니다.</div>;
+
+const Index = () => {
+  return (
+    <Suspense fallback={loading}>
+      <Routes>
+        {routes.map(({ path, element }) => (
+          <Route key={path} path={path} element={element} />
+        ))}
+      </Routes>
+    </Suspense>
+  );
+};
+
+export default Index;

--- a/src/pages/applications/index.tsx
+++ b/src/pages/applications/index.tsx
@@ -3,10 +3,12 @@ import { Route, Routes } from 'react-router-dom';
 
 const ApplicationDetail = React.lazy(() => import('./ApplicationDetail'));
 const ApplicationEdit = React.lazy(() => import('./ApplicationEdit'));
+const ApplicationAdd = React.lazy(() => import('./ApplicationAdd'));
 
 const routes = [
   { path: '/detail', element: <ApplicationDetail /> },
   { path: '/edit', element: <ApplicationEdit /> },
+  { path: '/add', element: <ApplicationAdd /> },
 ];
 
 const loading = <div>화면을 불러오는 중 입니다.</div>;

--- a/src/pages/main/Main.tsx
+++ b/src/pages/main/Main.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import styled from 'styled-components';
-import { Outlet, useNavigate } from 'react-router-dom';
+import { Outlet, useLocation, useNavigate } from 'react-router-dom';
 import Header from 'components/default/header/Header';
 import calendarToggle from 'assets/main/main_calendar_toggle.svg';
 import kanbanToggle from 'assets/main/main_kanban_toggle.svg';
@@ -9,27 +9,28 @@ const Main = () => {
   const navigate = useNavigate();
   const [isCalendar, setCalendar] = useState(localStorage.getItem('isCalendar') === 'true');
   const userInfo = localStorage.getItem('userInfo');
+  const { pathname } = useLocation();
 
   const toggleHandler = () => {
     const newIsCalendar = !isCalendar;
     setCalendar(newIsCalendar);
     localStorage.setItem('isCalendar', newIsCalendar.toString());
-  };
 
-  useEffect(() => {
     if (isCalendar) {
       navigate('/calendar');
     } else navigate('/kanban');
-  }, [isCalendar]);
+  };
 
   return (
     <Root>
       {userInfo && <Header />}
-      <ToggleContainer onClick={toggleHandler}>
-        <div className={`toggle-circle ${isCalendar ? '' : 'false'}`}>
-          <img src={isCalendar ? calendarToggle : kanbanToggle} alt='toggle' />
-        </div>
-      </ToggleContainer>
+      {(pathname === '/kanban' || pathname === '/calendar') && (
+        <ToggleContainer onClick={toggleHandler}>
+          <div className={`toggle-circle ${isCalendar ? '' : 'false'}`}>
+            <img src={isCalendar ? calendarToggle : kanbanToggle} alt='toggle' />
+          </div>
+        </ToggleContainer>
+      )}
       <Outlet />
     </Root>
   );

--- a/src/pages/main/Main.tsx
+++ b/src/pages/main/Main.tsx
@@ -39,6 +39,7 @@ const Main = () => {
 const Root = styled.div`
   display: flex;
   flex-direction: column;
+  overflow-x: hidden;
 `;
 
 const ToggleContainer = styled.div`

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -6,14 +6,12 @@ const Kanban = React.lazy(() => import('./pages/main/kanban/Kanban'));
 const Page404 = React.lazy(() => import('./pages/page404/Page404'));
 const Page500 = React.lazy(() => import('./pages/page500/Page500'));
 const DesiredPosition = React.lazy(() => import('./pages/signUp/DesiredPosition'));
-const ApplicationDetail = React.lazy(() => import('./pages/applications/ApplicationDetail'));
-const ApplicationEdit = React.lazy(() => import('./pages/applications/ApplicationEdit'));
+const Application = React.lazy(() => import('./pages/applications/index'));
 
 export const privateRoutes = [
   { path: '/calendar', element: <Calendar /> },
   { path: '/kanban', element: <Kanban /> },
-  { path: '/applicationDetail', element: <ApplicationDetail /> },
-  { path: '/applicatioEdit', element: <ApplicationEdit /> },
+  { path: '/application/*', element: <Application /> },
 ];
 
 export const publicRoutes = [

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -6,10 +6,14 @@ const Kanban = React.lazy(() => import('./pages/main/kanban/Kanban'));
 const Page404 = React.lazy(() => import('./pages/page404/Page404'));
 const Page500 = React.lazy(() => import('./pages/page500/Page500'));
 const DesiredPosition = React.lazy(() => import('./pages/signUp/DesiredPosition'));
+const ApplicationDetail = React.lazy(() => import('./pages/applications/ApplicationDetail'));
+const ApplicationEdit = React.lazy(() => import('./pages/applications/ApplicationEdit'));
 
 export const privateRoutes = [
   { path: '/calendar', element: <Calendar /> },
   { path: '/kanban', element: <Kanban /> },
+  { path: '/applicationDetail', element: <ApplicationDetail /> },
+  { path: '/applicatioEdit', element: <ApplicationEdit /> },
 ];
 
 export const publicRoutes = [


### PR DESCRIPTION
## 📖 작업 내용

- 지원서 추가, 지원서 상세, 지원서 수정 페이지 및 공통 레이아웃 생성
- react-hook-form 적용

## ✅ PR 포인트

- header의 내 지원서 추가 클릭 시 지원서 추가 페이지(/application/add)로 이동하게 처리했습니다. (이후 다른 버튼 페이지 생성 시 추가 처리 필요합니다.)
- 지원서 추가 페이지 -> /application/add
- 지원서 상세 페이지 -> /application/detail
- 지원서 수정 페이지 -> /application/edit
- api 연동 시 ApplicationEdit, ApplicationDetail에만 data를 내려주시면 됩니다.
- 레이아웃 컴포넌트에서 해당 데이터가 없는 경우 빈 배열로 처리했습니다.
- 버튼컴포넌트, 라디오 버튼 컴포넌트(고용형태, 경력조건, 근무형태), 전형단계관련 컴포넌트, input 컴포넌트의 경우 이후 조립 필요합니다.
- react-hook-form 으로 관리하기 위해서는 control를 내려줘야 합니다. 필요한 컴포넌트에 prop으로 넣어놨으니 이후 컴포넌트 수정 시 함께 내려주세요.
- 관련해서 이후 수정이 필요한 부분, 설명이 필요한 부분에는 주석을 추가했습니다.